### PR TITLE
Release: v1.0.0-beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@tetherto/wdk-wallet": "^1.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "A flexible manager that can register and manage multiple wallet instances for different blockchains dynamically.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.9

### Changes since v1.0.0-beta.8
- fix: move to null prototypes to avoid overzealous flagging (#53)
- docs: simplify README to Option A structure (#51)

Made with [Cursor](https://cursor.com)