### PR TITLE
fix(policy): forward arg snapshot to underlying method (close TOCTOU gap)

### DIFF
--- a/src/policy/policy-account-proxy.js
+++ b/src/policy/policy-account-proxy.js
@@ -156,8 +156,9 @@ function buildEnforcedMethod (name, boundOriginal, ctx) {
     // have the wallet receive different values than the policy approved
     // (time-of-check / time-of-use). The snapshot is taken independently of
     // the one inside buildContext, so a condition function also cannot mutate
-    // its way into the executed call. See snapshotArgs for cloning semantics.
-    const forwardedArgs = snapshotArgs(args)
+    // its way into the executed call. A non-cloneable argument fails closed
+    // here (see snapshotArgs) rather than being forwarded un-snapshotted.
+    const forwardedArgs = snapshotArgs(args, name)
 
     const context = buildContext({
       operation: name,

--- a/src/policy/policy-account-proxy.js
+++ b/src/policy/policy-account-proxy.js
@@ -150,21 +150,29 @@ export async function createPolicyEnforcedAccount (account, { blockchain, path, 
 
 function buildEnforcedMethod (name, boundOriginal, ctx) {
   return async function policyEnforced (...args) {
-    // Snapshot the arguments up front and forward *this* copy to the
-    // underlying method. Policy evaluation below is awaited, so a caller that
-    // mutates the original argument objects across that await could otherwise
-    // have the wallet receive different values than the policy approved
-    // (time-of-check / time-of-use). The snapshot is taken independently of
-    // the one inside buildContext, so a condition function also cannot mutate
-    // its way into the executed call. A non-cloneable argument fails closed
-    // here (see snapshotArgs) rather than being forwarded un-snapshotted.
+    // Snapshot the caller's arguments exactly once, up front, and treat that
+    // snapshot as the single source of truth: it is what we forward to the
+    // underlying method, and the condition context below is derived from it
+    // too. This matters for three reasons:
+    //   - Policy evaluation is awaited, so a caller that mutates the original
+    //     objects across that await must not change what reaches the wallet
+    //     (time-of-check / time-of-use).
+    //   - Reading the originals a second time to build the context could
+    //     observe *different* values (e.g. a getter/Proxy that returns a safe
+    //     value on first read and a malicious one on the next), splitting what
+    //     the policy checked from what executes. Cloning the already-captured
+    //     snapshot — plain data, no live accessors — avoids that.
+    //   - buildContext clones again, so the context the conditions see is
+    //     independent from forwardedArgs: a condition cannot mutate its way
+    //     into the executed call.
+    // A non-cloneable argument fails closed here (see snapshotArgs).
     const forwardedArgs = snapshotArgs(args, name)
 
     const context = buildContext({
       operation: name,
       wallet: ctx.blockchain,
       account: ctx.readOnlyAccount,
-      args
+      args: forwardedArgs
     })
 
     const verdict = await ctx.engine._evaluateContext(context, { path: ctx.account.path, index: ctx.index })

--- a/src/policy/policy-account-proxy.js
+++ b/src/policy/policy-account-proxy.js
@@ -150,22 +150,6 @@ export async function createPolicyEnforcedAccount (account, { blockchain, path, 
 
 function buildEnforcedMethod (name, boundOriginal, ctx) {
   return async function policyEnforced (...args) {
-    // Snapshot the caller's arguments exactly once, up front, and treat that
-    // snapshot as the single source of truth: it is what we forward to the
-    // underlying method, and the condition context below is derived from it
-    // too. This matters for three reasons:
-    //   - Policy evaluation is awaited, so a caller that mutates the original
-    //     objects across that await must not change what reaches the wallet
-    //     (time-of-check / time-of-use).
-    //   - Reading the originals a second time to build the context could
-    //     observe *different* values (e.g. a getter/Proxy that returns a safe
-    //     value on first read and a malicious one on the next), splitting what
-    //     the policy checked from what executes. Cloning the already-captured
-    //     snapshot — plain data, no live accessors — avoids that.
-    //   - buildContext clones again, so the context the conditions see is
-    //     independent from forwardedArgs: a condition cannot mutate its way
-    //     into the executed call.
-    // A non-cloneable argument fails closed here (see snapshotArgs).
     const forwardedArgs = snapshotArgs(args, name)
 
     const context = buildContext({

--- a/src/policy/policy-account-proxy.js
+++ b/src/policy/policy-account-proxy.js
@@ -15,7 +15,7 @@
 'use strict'
 
 import { OPERATIONS, PROTOCOL_METHODS } from './constants.js'
-import { buildContext } from './policy-context.js'
+import { buildContext, snapshotArgs } from './policy-context.js'
 import PolicyViolationError, { PolicyConfigurationError } from './policy-error.js'
 
 /** @typedef {import('@tetherto/wdk-wallet').IWalletAccount} IWalletAccount */
@@ -150,6 +150,15 @@ export async function createPolicyEnforcedAccount (account, { blockchain, path, 
 
 function buildEnforcedMethod (name, boundOriginal, ctx) {
   return async function policyEnforced (...args) {
+    // Snapshot the arguments up front and forward *this* copy to the
+    // underlying method. Policy evaluation below is awaited, so a caller that
+    // mutates the original argument objects across that await could otherwise
+    // have the wallet receive different values than the policy approved
+    // (time-of-check / time-of-use). The snapshot is taken independently of
+    // the one inside buildContext, so a condition function also cannot mutate
+    // its way into the executed call. See snapshotArgs for cloning semantics.
+    const forwardedArgs = snapshotArgs(args)
+
     const context = buildContext({
       operation: name,
       wallet: ctx.blockchain,
@@ -167,7 +176,7 @@ function buildEnforcedMethod (name, boundOriginal, ctx) {
       })
     }
 
-    return boundOriginal(...args)
+    return boundOriginal(...forwardedArgs)
   }
 }
 

--- a/src/policy/policy-context.js
+++ b/src/policy/policy-context.js
@@ -45,7 +45,7 @@
  * @returns {PolicyContext} A frozen context object.
  */
 export function buildContext ({ operation, wallet, account, args }) {
-  const safeArgs = Object.freeze(Array.from(args, snapshot))
+  const safeArgs = Object.freeze(snapshotArgs(args))
 
   return Object.freeze({
     operation,
@@ -54,6 +54,29 @@ export function buildContext ({ operation, wallet, account, args }) {
     params: safeArgs[0],
     args: safeArgs
   })
+}
+
+/**
+ * Clones each argument so the result is isolated from later mutation of the
+ * caller's originals (see {@link buildContext} for the cloning semantics and
+ * the non-cloneable fallback).
+ *
+ * Besides building the condition context, the wrapper forwards a snapshot of
+ * the arguments to the underlying wallet method. Cloning there closes a
+ * time-of-check / time-of-use gap: policy evaluation is asynchronous, and
+ * without an isolated copy a caller could mutate the original argument objects
+ * across that await (e.g. flip `tx.to` / `tx.value` after the policy already
+ * approved them) and have the mutated values reach the wallet. Each wrapped
+ * call takes its own snapshot, so the forwarded copy is also independent from
+ * the context the conditions see — a condition cannot mutate its way into the
+ * executed call.
+ *
+ * @internal
+ * @param {readonly unknown[]} args - The full argument array passed to the method.
+ * @returns {unknown[]} A new array whose elements are per-argument snapshots.
+ */
+export function snapshotArgs (args) {
+  return Array.from(args, snapshot)
 }
 
 function snapshot (value) {

--- a/src/policy/policy-context.js
+++ b/src/policy/policy-context.js
@@ -14,6 +14,8 @@
 
 'use strict'
 
+import { PolicyConfigurationError } from './policy-error.js'
+
 /** @typedef {import('@tetherto/wdk-wallet').IWalletAccountReadOnly} IWalletAccountReadOnly */
 /** @typedef {import('./policy-engine.js').PolicyContext} PolicyContext */
 
@@ -30,22 +32,20 @@
 /**
  * Builds the immutable context object passed to every condition function.
  *
- * Each cloneable argument is passed through structuredClone so condition
- * functions see a snapshot taken at evaluation time. This prevents
- * time-of-check / time-of-use mutation: a caller mutating the original
- * tx object after the wrapper builds the context (e.g., concurrent
- * middleware on a shared request body) cannot change what the conditions
- * already evaluated. The original arguments still flow through to the
- * underlying method untouched. Arguments that aren't structured-cloneable
- * (functions, class instances with non-cloneable internals) fall back to
- * their raw value.
+ * Each argument is passed through structuredClone so condition functions see
+ * a snapshot taken at evaluation time. This prevents time-of-check /
+ * time-of-use mutation: a caller mutating the original tx object after the
+ * wrapper builds the context (e.g., concurrent middleware on a shared request
+ * body) cannot change what the conditions already evaluated. Arguments that
+ * aren't structured-cloneable fail closed — see {@link snapshotArgs}.
  *
  * @internal
  * @param {BuildContextInput} input - The raw inputs from the wrapper.
  * @returns {PolicyContext} A frozen context object.
+ * @throws {PolicyConfigurationError} If any argument is not structured-cloneable.
  */
 export function buildContext ({ operation, wallet, account, args }) {
-  const safeArgs = Object.freeze(snapshotArgs(args))
+  const safeArgs = Object.freeze(snapshotArgs(args, operation))
 
   return Object.freeze({
     operation,
@@ -58,8 +58,7 @@ export function buildContext ({ operation, wallet, account, args }) {
 
 /**
  * Clones each argument so the result is isolated from later mutation of the
- * caller's originals (see {@link buildContext} for the cloning semantics and
- * the non-cloneable fallback).
+ * caller's originals.
  *
  * Besides building the condition context, the wrapper forwards a snapshot of
  * the arguments to the underlying wallet method. Cloning there closes a
@@ -71,15 +70,22 @@ export function buildContext ({ operation, wallet, account, args }) {
  * the context the conditions see — a condition cannot mutate its way into the
  * executed call.
  *
+ * Arguments that aren't structured-cloneable fail closed: snapshotting only
+ * runs for governed accounts, so silently forwarding the raw value would hand
+ * the wallet a shared mutable reference and re-open the very gap this exists
+ * to close. Throwing forces the caller to pass cloneable arguments instead.
+ *
  * @internal
  * @param {readonly unknown[]} args - The full argument array passed to the method.
+ * @param {string} [operation] - The operation name, used only to enrich the error message.
  * @returns {unknown[]} A new array whose elements are per-argument snapshots.
+ * @throws {PolicyConfigurationError} If any argument is not structured-cloneable.
  */
-export function snapshotArgs (args) {
-  return Array.from(args, snapshot)
+export function snapshotArgs (args, operation) {
+  return Array.from(args, (value, index) => snapshot(value, operation, index))
 }
 
-function snapshot (value) {
+function snapshot (value, operation, index) {
   if (value === null || typeof value !== 'object') return value
 
   try {
@@ -87,9 +93,20 @@ function snapshot (value) {
   } catch (err) {
     // structuredClone throws DOMException(name: 'DataCloneError') for values
     // it can't serialize (functions, class instances with non-cloneable
-    // internals, etc.). Fall back to the raw value in that case; rethrow
-    // anything else so real bugs surface.
-    if (err.name === 'DataCloneError') return value
+    // internals, etc.). Fail closed rather than forward an un-snapshotted
+    // reference; rethrow anything else so real bugs surface.
+    if (err.name === 'DataCloneError') {
+      const where = operation ? ` of governed operation '${operation}'` : ''
+
+      throw new PolicyConfigurationError(
+        `policy engine cannot snapshot argument ${index}${where}: value is not ` +
+        'structured-cloneable. Governed operations require cloneable arguments ' +
+        'so the engine can evaluate and forward the exact values it approved ' +
+        '(preventing time-of-check / time-of-use mutation). Pass a plain, ' +
+        'cloneable argument instead.'
+      )
+    }
+
     throw err
   }
 }

--- a/src/policy/policy-context.js
+++ b/src/policy/policy-context.js
@@ -91,10 +91,6 @@ function snapshot (value, operation, index) {
   try {
     return structuredClone(value)
   } catch (err) {
-    // structuredClone throws DOMException(name: 'DataCloneError') for values
-    // it can't serialize (functions, class instances with non-cloneable
-    // internals, etc.). Fail closed rather than forward an un-snapshotted
-    // reference; rethrow anything else so real bugs surface.
     if (err.name === 'DataCloneError') {
       const where = operation ? ` of governed operation '${operation}'` : ''
 

--- a/src/policy/policy-error.js
+++ b/src/policy/policy-error.js
@@ -68,7 +68,10 @@ export default class PolicyViolationError extends Error {
 }
 
 /**
- * Error type produced by the policy engine for invalid registration inputs.
+ * Error type produced by the policy engine when it cannot safely operate:
+ * invalid registration inputs, a governed wallet that doesn't implement the
+ * required read-only interface, or a governed call whose arguments cannot be
+ * snapshotted (not structured-cloneable).
  */
 export class PolicyConfigurationError extends Error {
   /**

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -1457,6 +1457,10 @@ describe('WDK — policy engine', () => {
   // -------------------------------------------------------------------------
 
   describe('context immutability', () => {
+    // Over the policy's value limit; what an attacker tries to slip past a
+    // check that already approved a smaller amount.
+    const ATTACKER_VALUE = 1_000_000_000_000_000_000n
+
     test('mutating the params object after the call starts does not change what conditions saw', async () => {
       let observedTo
 
@@ -1516,10 +1520,45 @@ describe('WDK — policy engine', () => {
       const callPromise = account.sendTransaction(tx)
 
       tx.to = SANCTIONED // caller mutates after the snapshot is taken
-      tx.value = 1_000_000_000_000_000_000n
+      tx.value = ATTACKER_VALUE
 
       await callPromise
 
+      expect(sendTransactionMock).toHaveBeenCalledWith({ to: RECIPIENT, value: 1n })
+    })
+
+    test('an argument whose getter returns different values per read cannot split the check from execution', async () => {
+      // A getter that flips its return on the second read could show the policy
+      // one value while the wallet executes another, unless the engine reads
+      // the caller's args exactly once. Capture what the condition evaluated
+      // and assert the wallet received that same value.
+      let evaluatedValue
+      const condition = jest.fn(({ params }) => {
+        evaluatedValue = params.value
+        return true
+      })
+
+      getAccountMock.mockResolvedValue(buildAccount())
+
+      wdk
+        .registerWallet('ethereum', WalletManagerMock, {})
+        .registerPolicy({
+          id: 'capture-value',
+          name: 'capture-value',
+          scope: 'project',
+          rules: [{ name: 'r', operation: 'sendTransaction', action: 'ALLOW', conditions: [condition] }]
+        })
+
+      const account = await wdk.getAccount('ethereum', 0)
+
+      let reads = 0
+      const tx = {
+        to: RECIPIENT,
+        get value () { reads += 1; return reads === 1 ? 1n : ATTACKER_VALUE }
+      }
+      await account.sendTransaction(tx)
+
+      expect(evaluatedValue).toBe(1n)
       expect(sendTransactionMock).toHaveBeenCalledWith({ to: RECIPIENT, value: 1n })
     })
 
@@ -1565,8 +1604,12 @@ describe('WDK — policy engine', () => {
       const err = await catchAsync(() => account.sendTransaction(tx))
 
       expect(err.name).toBe('PolicyConfigurationError')
-      expect(err.message).toMatch(/not structured-cloneable/)
-      expect(err.message).toMatch(/sendTransaction/)
+      expect(err.message).toBe(
+        "policy engine cannot snapshot argument 0 of governed operation 'sendTransaction': value is not " +
+        'structured-cloneable. Governed operations require cloneable arguments so the engine can evaluate ' +
+        'and forward the exact values it approved (preventing time-of-check / time-of-use mutation). ' +
+        'Pass a plain, cloneable argument instead.'
+      )
       expect(sendTransactionMock).not.toHaveBeenCalled()
     })
   })

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -1489,6 +1489,40 @@ describe('WDK — policy engine', () => {
       expect(observedTo).toBe(RECIPIENT)
     })
 
+    test('mutating the tx after the call starts does not change what the wallet receives', async () => {
+      // Reproduces the TOCTOU report: a slow async condition keeps the call
+      // pending while the caller swaps `to`/`value` on the original object
+      // after the policy approved the original values. The wallet must receive
+      // the approved snapshot, not the mutated object.
+      const condition = jest.fn(async ({ params }) => {
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        return params.to === RECIPIENT && params.value <= 5n
+      })
+
+      getAccountMock.mockResolvedValue(buildAccount())
+
+      wdk
+        .registerWallet('ethereum', WalletManagerMock, {})
+        .registerPolicy({
+          id: 'safe-recipient',
+          name: 'safe-recipient',
+          scope: 'project',
+          rules: [{ name: 'r', operation: 'sendTransaction', action: 'ALLOW', conditions: [condition] }]
+        })
+
+      const account = await wdk.getAccount('ethereum', 0)
+
+      const tx = { to: RECIPIENT, value: 1n }
+      const callPromise = account.sendTransaction(tx)
+
+      tx.to = SANCTIONED // caller mutates after the snapshot is taken
+      tx.value = 1_000_000_000_000_000_000n
+
+      await callPromise
+
+      expect(sendTransactionMock).toHaveBeenCalledWith({ to: RECIPIENT, value: 1n })
+    })
+
     test('a condition function cannot mutate its way into the underlying call', async () => {
       const condition = jest.fn(({ params }) => {
         params.to = SANCTIONED // mutation should not propagate

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -1457,8 +1457,6 @@ describe('WDK — policy engine', () => {
   // -------------------------------------------------------------------------
 
   describe('context immutability', () => {
-    // Over the policy's value limit; what an attacker tries to slip past a
-    // check that already approved a smaller amount.
     const ATTACKER_VALUE = 1_000_000_000_000_000_000n
 
     test('mutating the params object after the call starts does not change what conditions saw', async () => {
@@ -1494,10 +1492,6 @@ describe('WDK — policy engine', () => {
     })
 
     test('mutating the tx after the call starts does not change what the wallet receives', async () => {
-      // Reproduces the TOCTOU report: a slow async condition keeps the call
-      // pending while the caller swaps `to`/`value` on the original object
-      // after the policy approved the original values. The wallet must receive
-      // the approved snapshot, not the mutated object.
       const condition = jest.fn(async ({ params }) => {
         await new Promise((resolve) => setTimeout(resolve, 30))
         return params.to === RECIPIENT && params.value <= 5n
@@ -1519,7 +1513,7 @@ describe('WDK — policy engine', () => {
       const tx = { to: RECIPIENT, value: 1n }
       const callPromise = account.sendTransaction(tx)
 
-      tx.to = SANCTIONED // caller mutates after the snapshot is taken
+      tx.to = SANCTIONED
       tx.value = ATTACKER_VALUE
 
       await callPromise
@@ -1528,10 +1522,6 @@ describe('WDK — policy engine', () => {
     })
 
     test('an argument whose getter returns different values per read cannot split the check from execution', async () => {
-      // A getter that flips its return on the second read could show the policy
-      // one value while the wallet executes another, unless the engine reads
-      // the caller's args exactly once. Capture what the condition evaluated
-      // and assert the wallet received that same value.
       let evaluatedValue
       const condition = jest.fn(({ params }) => {
         evaluatedValue = params.value
@@ -1589,9 +1579,6 @@ describe('WDK — policy engine', () => {
     })
 
     test('a non-cloneable governed argument fails closed instead of forwarding a shared reference', async () => {
-      // A value structuredClone cannot serialize would otherwise reach the
-      // wallet as a shared mutable reference, re-opening the TOCTOU gap. The
-      // engine must refuse the call rather than forward it un-snapshotted.
       getAccountMock.mockResolvedValue(buildAccount())
 
       wdk
@@ -1600,7 +1587,7 @@ describe('WDK — policy engine', () => {
 
       const account = await wdk.getAccount('ethereum', 0)
 
-      const tx = { to: RECIPIENT, value: 1n, onSettled: () => {} } // function → not cloneable
+      const tx = { to: RECIPIENT, value: 1n, onSettled: () => {} }
       const err = await catchAsync(() => account.sendTransaction(tx))
 
       expect(err.name).toBe('PolicyConfigurationError')

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -1548,6 +1548,27 @@ describe('WDK — policy engine', () => {
       expect(sendTransactionMock).toHaveBeenCalledWith({ to: RECIPIENT, value: 1n })
       expect(tx.to).toBe(RECIPIENT) // caller's object also unchanged
     })
+
+    test('a non-cloneable governed argument fails closed instead of forwarding a shared reference', async () => {
+      // A value structuredClone cannot serialize would otherwise reach the
+      // wallet as a shared mutable reference, re-opening the TOCTOU gap. The
+      // engine must refuse the call rather than forward it un-snapshotted.
+      getAccountMock.mockResolvedValue(buildAccount())
+
+      wdk
+        .registerWallet('ethereum', WalletManagerMock, {})
+        .registerPolicy(projectAllowAll('p'))
+
+      const account = await wdk.getAccount('ethereum', 0)
+
+      const tx = { to: RECIPIENT, value: 1n, onSettled: () => {} } // function → not cloneable
+      const err = await catchAsync(() => account.sendTransaction(tx))
+
+      expect(err.name).toBe('PolicyConfigurationError')
+      expect(err.message).toMatch(/not structured-cloneable/)
+      expect(err.message).toMatch(/sendTransaction/)
+      expect(sendTransactionMock).not.toHaveBeenCalled()
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/types/src/policy/policy-context.d.ts
+++ b/types/src/policy/policy-context.d.ts
@@ -12,25 +12,22 @@
 /**
  * Builds the immutable context object passed to every condition function.
  *
- * Each cloneable argument is passed through structuredClone so condition
- * functions see a snapshot taken at evaluation time. This prevents
- * time-of-check / time-of-use mutation: a caller mutating the original
- * tx object after the wrapper builds the context (e.g., concurrent
- * middleware on a shared request body) cannot change what the conditions
- * already evaluated. The original arguments still flow through to the
- * underlying method untouched. Arguments that aren't structured-cloneable
- * (functions, class instances with non-cloneable internals) fall back to
- * their raw value.
+ * Each argument is passed through structuredClone so condition functions see
+ * a snapshot taken at evaluation time. This prevents time-of-check /
+ * time-of-use mutation: a caller mutating the original tx object after the
+ * wrapper builds the context (e.g., concurrent middleware on a shared request
+ * body) cannot change what the conditions already evaluated. Arguments that
+ * aren't structured-cloneable fail closed — see {@link snapshotArgs}.
  *
  * @internal
  * @param {BuildContextInput} input - The raw inputs from the wrapper.
  * @returns {PolicyContext} A frozen context object.
+ * @throws {PolicyConfigurationError} If any argument is not structured-cloneable.
  */
 export function buildContext({ operation, wallet, account, args }: BuildContextInput): PolicyContext;
 /**
  * Clones each argument so the result is isolated from later mutation of the
- * caller's originals (see {@link buildContext} for the cloning semantics and
- * the non-cloneable fallback).
+ * caller's originals.
  *
  * Besides building the condition context, the wrapper forwards a snapshot of
  * the arguments to the underlying wallet method. Cloning there closes a
@@ -42,11 +39,18 @@ export function buildContext({ operation, wallet, account, args }: BuildContextI
  * the context the conditions see — a condition cannot mutate its way into the
  * executed call.
  *
+ * Arguments that aren't structured-cloneable fail closed: snapshotting only
+ * runs for governed accounts, so silently forwarding the raw value would hand
+ * the wallet a shared mutable reference and re-open the very gap this exists
+ * to close. Throwing forces the caller to pass cloneable arguments instead.
+ *
  * @internal
  * @param {readonly unknown[]} args - The full argument array passed to the method.
+ * @param {string} [operation] - The operation name, used only to enrich the error message.
  * @returns {unknown[]} A new array whose elements are per-argument snapshots.
+ * @throws {PolicyConfigurationError} If any argument is not structured-cloneable.
  */
-export function snapshotArgs(args: readonly unknown[]): unknown[];
+export function snapshotArgs(args: readonly unknown[], operation?: string): unknown[];
 export type IWalletAccountReadOnly = import("@tetherto/wdk-wallet").IWalletAccountReadOnly;
 export type PolicyContext = import("./policy-engine.js").PolicyContext;
 /**

--- a/types/src/policy/policy-context.d.ts
+++ b/types/src/policy/policy-context.d.ts
@@ -27,6 +27,26 @@
  * @returns {PolicyContext} A frozen context object.
  */
 export function buildContext({ operation, wallet, account, args }: BuildContextInput): PolicyContext;
+/**
+ * Clones each argument so the result is isolated from later mutation of the
+ * caller's originals (see {@link buildContext} for the cloning semantics and
+ * the non-cloneable fallback).
+ *
+ * Besides building the condition context, the wrapper forwards a snapshot of
+ * the arguments to the underlying wallet method. Cloning there closes a
+ * time-of-check / time-of-use gap: policy evaluation is asynchronous, and
+ * without an isolated copy a caller could mutate the original argument objects
+ * across that await (e.g. flip `tx.to` / `tx.value` after the policy already
+ * approved them) and have the mutated values reach the wallet. Each wrapped
+ * call takes its own snapshot, so the forwarded copy is also independent from
+ * the context the conditions see — a condition cannot mutate its way into the
+ * executed call.
+ *
+ * @internal
+ * @param {readonly unknown[]} args - The full argument array passed to the method.
+ * @returns {unknown[]} A new array whose elements are per-argument snapshots.
+ */
+export function snapshotArgs(args: readonly unknown[]): unknown[];
 export type IWalletAccountReadOnly = import("@tetherto/wdk-wallet").IWalletAccountReadOnly;
 export type PolicyContext = import("./policy-engine.js").PolicyContext;
 /**

--- a/types/src/policy/policy-error.d.ts
+++ b/types/src/policy/policy-error.d.ts
@@ -35,7 +35,10 @@ export default class PolicyViolationError extends Error {
     #private;
 }
 /**
- * Error type produced by the policy engine for invalid registration inputs.
+ * Error type produced by the policy engine when it cannot safely operate:
+ * invalid registration inputs, a governed wallet that doesn't implement the
+ * required read-only interface, or a governed call whose arguments cannot be
+ * snapshotted (not structured-cloneable).
  */
 export class PolicyConfigurationError extends Error {
     /**


### PR DESCRIPTION
## Problem

A TOCTOU (time-of-check / time-of-use) gap in the local transaction policy engine introduced in #55 (shipped in `v1.0.0-beta.11`).

The enforced-method wrapper in `policy-account-proxy.js` evaluated policies against a `structuredClone` **snapshot** of the args, but then invoked the underlying wallet method with the caller's **original, mutable** args:

```js
const context = buildContext({ ..., args })             // snapshot evaluated
const verdict = await ctx.engine._evaluateContext(...)  // ← async gap
...
return boundOriginal(...args)                           // ← original mutable args
```

Because policy evaluation is `await`ed, a caller can mutate the original `tx` object **after** the policy approved the original values, and the wallet receives the mutated transaction — bypassing recipient/value limits.

```js
// @tetherto/wdk@1.0.0-beta.11
// Policy ALLOW: tx.to === SAFE && tx.value <= 5
const tx = { to: SAFE, value: 1n }
const pending = account.sendTransaction(tx)   // policy sees SAFE / 1
tx.to = ATTACKER
tx.value = 1_000_000_000_000_000_000n
await pending                                  // wallet receives ATTACKER / 1e18
```

## Fix

Take an **independent** snapshot of the args up front and forward *that* copy to the underlying method, so what the policy approved is exactly what executes:

```js
const forwardedArgs = snapshotArgs(args)   // captured synchronously, before the await
...
return boundOriginal(...forwardedArgs)
```

Two properties matter:
- It's captured **synchronously** before the await, so caller mutation across the await can't reach it.
- It's a **separate** clone from `context.args`, which preserves the existing invariant (test `a condition function cannot mutate its way into the underlying call`) that a condition function can't mutate its way into the executed call.

`snapshotArgs` is factored out of `buildContext` so both paths use identical `structuredClone`-with-fallback semantics.

## Why cloning is safe

Wallet methods only read/spread plain-object args (`...tx`, `{ token, spender, amount }`) — nothing relies on object identity or prototypes. Non-cloneable args (e.g. a paymaster config holding class instances) fall back to their raw value, matching the snapshot semantics already used for evaluation.

## Tests

Adds a regression test reproducing the report: a slow `ALLOW` condition keeps the call pending while the caller swaps `to`/`value`; the test asserts the wallet receives the approved snapshot, not the mutated object. The prior tests only checked what the *condition* saw, never what the wallet *executed*.

- Verified the new test **fails without the fix** (wallet got `ATTACKER` / `1e18`) and **passes with it**.
- Full suite: **129/129 pass**. `standard` lint clean. `tsc` type build clean (regenerated `.d.ts` included).