### PR TITLE
feat(policy)!: drop context.params, standardize on args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const wdk = new WDK(seedPhrase)
       name: 'allow-under-1-eth',
       operation: 'sendTransaction',
       action: 'ALLOW',
-      conditions: [({ params }) => BigInt(params.value) <= 10n ** 18n]
+      conditions: [({ args }) => BigInt(args[0].value) <= 10n ** 18n]
     }]
   })
 
@@ -100,6 +100,30 @@ const result = await account.simulate.sendTransaction({ to: '0x…', value: 1n }
 
 Policies have two scopes — `project` and `account`. A project-scope policy applies globally by default, or only to the wallets named in its `wallet` field (`wallet: 'ethereum'` or `wallet: ['ethereum', 'ton']`). The `wallet` value is the same string passed to `registerWallet`. It might be a chain name like `"ethereum"`, but it could equally be `"treasury-cold"` or any label the consumer chose; the engine treats it as an opaque key. An account-scope policy must declare a `wallet` and targets specific accounts within it, identified by either derivation path (`accounts: ["0'/0/0"]`) or integer index (`accounts: [0, 1]`) — index entries match accounts retrieved via `wdk.getAccount(wallet, index)`; path entries match either retrieval style. Evaluation is narrowest-first with `DENY` winning across scopes. Account-scope `ALLOW` rules can opt into `override_broader_scope: true` to short-circuit broader policies for explicit exceptions (e.g., treasury accounts). Conditions can be sync or async and may carry user-owned state via closures. Templates (`@tetherto/wdk-policy-templates`) and a portal UI for editing policies are coming in later phases.
 
+### Condition context
+
+Every condition receives a single frozen context object with four fields: `operation` (the intercepted operation name), `wallet` (the identifier the account belongs to — the same string passed to `registerWallet`), `account` (a read-only view exposing reads and quotes but no signing or write methods), and `args` (the full argument array the call was made with, snapshotted at evaluation time).
+
+Arguments are read positionally through `args`, which works for every operation shape — including multi-argument ones:
+
+```javascript
+// sendTransaction(tx) — the transaction is args[0]
+conditions: [({ args }) => BigInt(args[0].value) <= 10n ** 18n]
+
+// swidge(options, config) — gate on the second argument
+conditions: [({ args }) => args[1].slippage <= 0.05]
+```
+
+> **Breaking change:** `context.params`, a shortcut for `args[0]`, has been removed. It was invisible past the first argument, so multi-argument operations had to reach for `args` anyway. Migrate positional access to `args`:
+>
+> ```javascript
+> // Before
+> conditions: [({ params }) => params.to === '0x…']
+>
+> // After
+> conditions: [({ args }) => args[0].to === '0x…']
+> ```
+
 ### Default-deny semantics
 
 The engine is **default-deny on governed accounts**. As soon as any policy applies to an account, the engine wraps every method in `OPERATIONS` (the set of write-facing and signing primitives — `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, and protocol methods like `swap`, `bridge`, `swidge`, etc.) on that account. Any call to a wrapped method whose operation is not addressed by an `ALLOW` rule throws `PolicyViolationError` with `reason: 'no-applicable-rule'`.
@@ -114,7 +138,7 @@ wdk.registerPolicy({
   scope: 'project',
   rules: [
     { name: 'allow-all', operation: '*', action: 'ALLOW', conditions: [] },
-    { name: 'block-bad', operation: 'sendTransaction', action: 'DENY', conditions: [({ params }) => isSanctioned(params.to)] }
+    { name: 'block-bad', operation: 'sendTransaction', action: 'DENY', conditions: [({ args }) => isSanctioned(args[0].to)] }
   ]
 })
 ```

--- a/README.md
+++ b/README.md
@@ -110,9 +110,12 @@ Arguments are read positionally through `args`, which works for every operation 
 // sendTransaction(tx) — the transaction is args[0]
 conditions: [({ args }) => BigInt(args[0].value) <= 10n ** 18n]
 
-// swidge(options, config) — gate on the second argument
-conditions: [({ args }) => args[1].slippage <= 0.05]
+// swidge(options, config) — slippage lives on options, the fee caps on config
+conditions: [({ args }) => args[0].slippage <= 0.05]
+conditions: [({ args }) => args[1] !== undefined && args[1].maxProtocolFeeBps <= 50]
 ```
+
+Index positionally against the operation's real signature, and remember that trailing arguments are often optional — `swidge`'s `config` is. Reading a field off an argument that wasn't passed throws, and reading one that lives on a different argument silently yields `undefined`, which compares falsy: either way the rule stops guarding what you think it guards. Check the argument exists before reaching into it.
 
 > **Breaking change:** `context.params`, a shortcut for `args[0]`, has been removed. It was invisible past the first argument, so multi-argument operations had to reach for `args` anyway. Migrate positional access to `args`:
 >

--- a/src/policy/policy-context.js
+++ b/src/policy/policy-context.js
@@ -51,7 +51,6 @@ export function buildContext ({ operation, wallet, account, args }) {
     operation,
     wallet,
     account,
-    params: safeArgs[0],
     args: safeArgs
   })
 }

--- a/src/policy/policy-engine.js
+++ b/src/policy/policy-engine.js
@@ -56,8 +56,7 @@ import {
  * @property {PolicyOperation} operation - The intercepted operation name.
  * @property {string} wallet - The wallet identifier (the same string passed to `wdk.registerWallet`). Despite the name, this is an opaque key chosen by the consumer — it might be a chain name like `"ethereum"`, but it could equally be `"treasury-cold"` or any other label.
  * @property {IWalletAccountReadOnly} account - A read-only view of the wallet account.
- * @property {unknown} params - The first argument to the wrapped method.
- * @property {readonly unknown[]} args - The full argument array.
+ * @property {readonly unknown[]} args - The full argument array the wrapped method was called with, snapshotted at evaluation time. `args[0]` is the first argument; every element is readable, so multi-argument operations (e.g. `swidge(options, config)`) can be gated on any of them.
  */
 
 /**

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -2182,17 +2182,17 @@ describe('WDK — policy engine', () => {
         .registerWallet('ethereum', WalletManagerMock, {})
         .registerProtocol('ethereum', 'bridge-and-swap', MySwidgeProtocol, {})
         .registerPolicy({
-          id: 'slippage-cap',
-          name: 'slippage-cap',
+          id: 'protocol-fee-cap',
+          name: 'protocol-fee-cap',
           scope: 'project',
           rules: [
             {
-              name: 'deny-high-slippage',
+              name: 'deny-uncapped-protocol-fee',
               operation: 'swidge',
               action: 'DENY',
               conditions: [({ args }) => {
                 observedArgs.push(args)
-                return args[1].slippage > 0.05
+                return args[1] === undefined || args[1].maxProtocolFeeBps > 50
               }]
             },
             { name: 'allow-swidge', operation: 'swidge', action: 'ALLOW', conditions: [] }
@@ -2203,18 +2203,22 @@ describe('WDK — policy engine', () => {
       const swidge = account.getSwidgeProtocol('bridge-and-swap')
 
       const options = { fromToken: 'A', toToken: 'B', fromTokenAmount: 1n }
-      const allowed = await swidge.swidge(options, { slippage: 0.01 })
-      const denied = await catchAsync(() => swidge.swidge(options, { slippage: 0.5 }))
+      const allowed = await swidge.swidge(options, { maxProtocolFeeBps: 25 })
+      const overCap = await catchAsync(() => swidge.swidge(options, { maxProtocolFeeBps: 500 }))
+      const noConfig = await catchAsync(() => swidge.swidge(options))
 
       expect(allowed).toEqual(DUMMY_SWIDGE_RESULT)
-      expect(denied.name).toBe('PolicyViolationError')
-      expect(denied.policyId).toBe('slippage-cap')
-      expect(denied.ruleName).toBe('deny-high-slippage')
+      expect(overCap.name).toBe('PolicyViolationError')
+      expect(overCap.policyId).toBe('protocol-fee-cap')
+      expect(overCap.ruleName).toBe('deny-uncapped-protocol-fee')
+      expect(noConfig.name).toBe('PolicyViolationError')
+      expect(noConfig.ruleName).toBe('deny-uncapped-protocol-fee')
       expect(swidgeInstanceMock).toHaveBeenCalledTimes(1)
-      expect(swidgeInstanceMock).toHaveBeenCalledWith(options, { slippage: 0.01 })
+      expect(swidgeInstanceMock).toHaveBeenCalledWith(options, { maxProtocolFeeBps: 25 })
       expect(observedArgs).toEqual([
-        [options, { slippage: 0.01 }],
-        [options, { slippage: 0.5 }]
+        [options, { maxProtocolFeeBps: 25 }],
+        [options, { maxProtocolFeeBps: 500 }],
+        [options]
       ])
     })
   })

--- a/tests/wdk-policy.test.js
+++ b/tests/wdk-policy.test.js
@@ -339,7 +339,7 @@ describe('WDK — policy engine', () => {
       const expectedContext = expect.objectContaining({
         operation: 'sendTransaction',
         wallet: 'ethereum',
-        params: { to: RECIPIENT, value: 1n }
+        args: [{ to: RECIPIENT, value: 1n }]
       })
 
       expect(firstCondition).toHaveBeenCalledTimes(1)
@@ -624,7 +624,7 @@ describe('WDK — policy engine', () => {
             name: 'cap',
             operation: 'transfer',
             action: 'ALLOW',
-            conditions: [({ params }) => BigInt(params.amount) <= 100n]
+            conditions: [({ args }) => BigInt(args[0].amount) <= 100n]
           }]
         })
 
@@ -1011,7 +1011,7 @@ describe('WDK — policy engine', () => {
             name: 'allow-small',
             operation: 'sendTransaction',
             action: 'ALLOW',
-            conditions: [({ params }) => BigInt(params.value) <= 5n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 5n]
           }]
         })
 
@@ -1095,7 +1095,7 @@ describe('WDK — policy engine', () => {
             name: 'allow-small',
             operation: 'sendTransaction',
             action: 'ALLOW',
-            conditions: [({ params }) => BigInt(params.value) <= 5n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 5n]
           }]
         })
 
@@ -1217,8 +1217,8 @@ describe('WDK — policy engine', () => {
             name: 'cap',
             operation: 'sendTransaction',
             action: 'ALLOW',
-            conditions: [({ params }) => {
-              const next = totalSpent + BigInt(params.value)
+            conditions: [({ args }) => {
+              const next = totalSpent + BigInt(args[0].value)
               if (next > cap) return false
               totalSpent = next
               return true
@@ -1319,7 +1319,7 @@ describe('WDK — policy engine', () => {
             name: 'allow-small',
             operation: 'sendTransaction',
             action: 'ALLOW',
-            conditions: [({ params }) => BigInt(params.value) <= 100n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 100n]
           }]
         })
         .registerPolicy({
@@ -1330,7 +1330,7 @@ describe('WDK — policy engine', () => {
             name: 'block-bad',
             operation: 'sendTransaction',
             action: 'DENY',
-            conditions: [({ params }) => params.to === SANCTIONED]
+            conditions: [({ args }) => args[0].to === SANCTIONED]
           }]
         })
 
@@ -1358,7 +1358,7 @@ describe('WDK — policy engine', () => {
             operation: 'sendTransaction',
             action: 'ALLOW',
             override_broader_scope: true,
-            conditions: [({ params }) => BigInt(params.value) <= 100n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 100n]
           }]
         })
         .registerPolicy({
@@ -1397,7 +1397,7 @@ describe('WDK — policy engine', () => {
             operation: 'sendTransaction',
             action: 'ALLOW',
             override_broader_scope: true,
-            conditions: [({ params }) => BigInt(params.value) <= 100n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 100n]
           }]
         })
         .registerPolicy({
@@ -1408,7 +1408,7 @@ describe('WDK — policy engine', () => {
             name: 'block-bad',
             operation: 'sendTransaction',
             action: 'DENY',
-            conditions: [({ params }) => params.to === SANCTIONED]
+            conditions: [({ args }) => args[0].to === SANCTIONED]
           }]
         })
 
@@ -1495,7 +1495,7 @@ describe('WDK — policy engine', () => {
             name: 'allow-small',
             operation: 'sendTransaction',
             action: 'ALLOW',
-            conditions: [({ params }) => BigInt(params.value) <= 5n]
+            conditions: [({ args }) => BigInt(args[0].value) <= 5n]
           }]
         })
 
@@ -1594,7 +1594,7 @@ describe('WDK — policy engine', () => {
       expect(condition).toHaveBeenCalledWith(expect.objectContaining({
         operation: 'approve',
         wallet: 'ethereum',
-        params: { token: TOKEN, spender: SPENDER, amount: 1n }
+        args: [{ token: TOKEN, spender: SPENDER, amount: 1n }]
       }))
       expect(sendTransactionMock).toHaveBeenCalledTimes(1)
       expect(sendTransactionMock).toHaveBeenCalledWith({ to: SPENDER, value: 0n })
@@ -1636,12 +1636,12 @@ describe('WDK — policy engine', () => {
       expect(condition).toHaveBeenNthCalledWith(1, expect.objectContaining({
         operation: 'sendTransaction',
         wallet: 'ethereum',
-        params: { to: RECIPIENT, value: 1n }
+        args: [{ to: RECIPIENT, value: 1n }]
       }))
       expect(condition).toHaveBeenNthCalledWith(2, expect.objectContaining({
         operation: 'sendTransaction',
         wallet: 'ethereum',
-        params: { to: RECIPIENT, value: 2n }
+        args: [{ to: RECIPIENT, value: 2n }]
       }))
       expect(sendTransactionMock).toHaveBeenCalledTimes(2)
       expect(sendTransactionMock).toHaveBeenNthCalledWith(1, { to: RECIPIENT, value: 1n })
@@ -1687,13 +1687,13 @@ describe('WDK — policy engine', () => {
   describe('context immutability', () => {
     const ATTACKER_VALUE = 1_000_000_000_000_000_000n
 
-    test('mutating the params object after the call starts does not change what conditions saw', async () => {
+    test('mutating the argument object after the call starts does not change what conditions saw', async () => {
       let observedTo
 
       // Slow async condition gives the user time to mutate the original object.
-      const condition = jest.fn(async ({ params }) => {
+      const condition = jest.fn(async ({ args }) => {
         await new Promise((resolve) => setTimeout(resolve, 30))
-        observedTo = params.to
+        observedTo = args[0].to
         return true
       })
 
@@ -1720,9 +1720,9 @@ describe('WDK — policy engine', () => {
     })
 
     test('mutating the tx after the call starts does not change what the wallet receives', async () => {
-      const condition = jest.fn(async ({ params }) => {
+      const condition = jest.fn(async ({ args }) => {
         await new Promise((resolve) => setTimeout(resolve, 30))
-        return params.to === RECIPIENT && params.value <= 5n
+        return args[0].to === RECIPIENT && args[0].value <= 5n
       })
 
       getAccountMock.mockResolvedValue(buildAccount())
@@ -1751,8 +1751,8 @@ describe('WDK — policy engine', () => {
 
     test('an argument whose getter returns different values per read cannot split the check from execution', async () => {
       let evaluatedValue
-      const condition = jest.fn(({ params }) => {
-        evaluatedValue = params.value
+      const condition = jest.fn(({ args }) => {
+        evaluatedValue = args[0].value
         return true
       })
 
@@ -1781,8 +1781,8 @@ describe('WDK — policy engine', () => {
     })
 
     test('a condition function cannot mutate its way into the underlying call', async () => {
-      const condition = jest.fn(({ params }) => {
-        params.to = SANCTIONED // mutation should not propagate
+      const condition = jest.fn(({ args }) => {
+        args[0].to = SANCTIONED // mutation should not propagate
         return true
       })
 
@@ -2132,7 +2132,7 @@ describe('WDK — policy engine', () => {
   // -------------------------------------------------------------------------
 
   describe('context object', () => {
-    test('the condition function receives operation, wallet, params, args, and a read-only account', async () => {
+    test('the condition function receives operation, wallet, args, and a read-only account', async () => {
       let captured
 
       getAccountMock.mockResolvedValue(buildAccount())
@@ -2156,14 +2156,66 @@ describe('WDK — policy engine', () => {
 
       expect(captured.operation).toBe('sendTransaction')
       expect(captured.wallet).toBe('base')
-      expect(captured.params).toEqual({ to: RECIPIENT, value: 7n })
       expect(captured.args).toHaveLength(2)
       expect(captured.args[0]).toEqual({ to: RECIPIENT, value: 7n })
       expect(captured.args[1]).toEqual({ gas: 21000 })
+      expect(captured.params).toBeUndefined()
       expect(captured.account.path).toBe(PATH_DEFAULT)
       expect(captured.account.sendTransaction).toBeUndefined()
       expect(captured.account.transfer).toBeUndefined()
       expect(Object.isFrozen(captured)).toBe(true)
+    })
+
+    test('a condition can gate a multi-argument operation on an argument other than the first', async () => {
+      const swidgeInstanceMock = jest.fn().mockResolvedValue(DUMMY_SWIDGE_RESULT)
+
+      class MySwidgeProtocol extends SwidgeProtocol {
+        constructor () { super() }
+        async swidge (options, config) { return swidgeInstanceMock(options, config) }
+      }
+
+      getAccountMock.mockResolvedValue(buildAccount())
+
+      const observedArgs = []
+
+      wdk
+        .registerWallet('ethereum', WalletManagerMock, {})
+        .registerProtocol('ethereum', 'bridge-and-swap', MySwidgeProtocol, {})
+        .registerPolicy({
+          id: 'slippage-cap',
+          name: 'slippage-cap',
+          scope: 'project',
+          rules: [
+            {
+              name: 'deny-high-slippage',
+              operation: 'swidge',
+              action: 'DENY',
+              conditions: [({ args }) => {
+                observedArgs.push(args)
+                return args[1].slippage > 0.05
+              }]
+            },
+            { name: 'allow-swidge', operation: 'swidge', action: 'ALLOW', conditions: [] }
+          ]
+        })
+
+      const account = await wdk.getAccount('ethereum', 0)
+      const swidge = account.getSwidgeProtocol('bridge-and-swap')
+
+      const options = { fromToken: 'A', toToken: 'B', fromTokenAmount: 1n }
+      const allowed = await swidge.swidge(options, { slippage: 0.01 })
+      const denied = await catchAsync(() => swidge.swidge(options, { slippage: 0.5 }))
+
+      expect(allowed).toEqual(DUMMY_SWIDGE_RESULT)
+      expect(denied.name).toBe('PolicyViolationError')
+      expect(denied.policyId).toBe('slippage-cap')
+      expect(denied.ruleName).toBe('deny-high-slippage')
+      expect(swidgeInstanceMock).toHaveBeenCalledTimes(1)
+      expect(swidgeInstanceMock).toHaveBeenCalledWith(options, { slippage: 0.01 })
+      expect(observedArgs).toEqual([
+        [options, { slippage: 0.01 }],
+        [options, { slippage: 0.5 }]
+      ])
     })
   })
 

--- a/types/src/policy/policy-engine.d.ts
+++ b/types/src/policy/policy-engine.d.ts
@@ -83,11 +83,7 @@ export type PolicyContext = {
      */
     account: IWalletAccountReadOnly;
     /**
-     * - The first argument to the wrapped method.
-     */
-    params: unknown;
-    /**
-     * - The full argument array.
+     * - The full argument array the wrapped method was called with, snapshotted at evaluation time. `args[0]` is the first argument; every element is readable, so multi-argument operations (e.g. `swidge(options, config)`) can be gated on any of them.
      */
     args: readonly unknown[];
 };


### PR DESCRIPTION
> **Breaking change.** See the migration snippet at the bottom — it's ready to lift into the release notes verbatim.

## Problem

`buildContext()` hardcoded `params: safeArgs[0]`. It read as the canonical way to reach a call's arguments, but it only ever exposed the first one. For a single-argument method like `sendTransaction(tx)` that was a harmless shortcut; for `swidge(options, config)` it was actively misleading — `params === options` and `config` was invisible unless the condition reached for `args` anyway.

So the engine shipped two ways to read arguments, one of which silently under-reports on any operation taking more than one. Conditions written against `params` can't express "cap slippage" on a swidge, and nothing in the field name says why.

## Change

`params` is gone. `args` is the single positional accessor, and it already carried everything `params` did (`args[0]` is the same snapshotted value, from the same `snapshotArgs()` pass).

- `params: safeArgs[0]` removed from `buildContext()`
- `params` removed from the `PolicyContext` typedef and the hand-maintained `.d.ts`
- `args` doc expanded to state that every element is readable and that multi-argument operations can be gated on any of them

No change to `args` semantics, freeze behaviour, or the snapshot/TOCTOU posture — `args` is the same frozen array of `structuredClone`d values it already was. No helper (`context.arg(i)` or similar) was added; no deprecation phase, per the direct-removal call.

## Tests

152 passing, `standard` clean.

- Every condition in the suite migrated from `({ params })` to `({ args }) => args[0]`, and the three `expect.objectContaining({ ..., params: X })` context assertions became `args: [X]`.
- The `context object` test now asserts `captured.params` is `undefined`. The context is frozen, so this pins the removal — nothing can quietly re-add the field.
- **New:** `a condition can gate a multi-argument operation on an argument other than the first`. A swidge protocol whose `swidge(options, config)` takes two arguments, gated by a DENY rule reading `args[1].slippage`. It asserts the low-slippage call executes, the high-slippage call throws `PolicyViolationError` with the expected rule name, the underlying protocol method ran exactly once, and both observed `args` arrays contain both elements. This is what `params` structurally could not express.

The `context immutability` block kept all four of its guarantees — notably `a condition function cannot mutate its way into the underlying call` still holds via `args[0].to = SANCTIONED`, since the wrapper snapshots separately from the context.

## Docs

New **Condition context** section in the README documenting all four context fields, with side-by-side examples of a single-argument (`sendTransaction`) and a multi-argument (`swidge`) condition — the case that motivated the removal. The two existing README policy examples were migrated. `AGENTS.md` never documented the context field shape, so nothing there went stale.

## Release note / migration

```js
// Before
conditions: [({ params }) => params.to === '0x...']

// After
conditions: [({ args }) => args[0].to === '0x...']
```

Mechanical for the single-argument case: destructure `args` instead of `params` and index `[0]`. Consumers on a multi-argument operation gain access to arguments they previously couldn't see.

## Notes

- Other `PolicyContext` fields (`operation`, `wallet`, `account`) untouched.
- No version bump: this repo bumps `package.json` in dedicated `chore: release` commits on release branches. Breaking, but the channel is still beta and the `!` in the commit type marks the break.
- Branched off `main`, independent of #78 (per-policy timeouts). The two touch disjoint regions of `policy-engine.js` and `tests/wdk-policy.test.js`, so they should merge in either order — worth a quick check on whichever lands second.
