### PR TITLE
fix: validate raw seed length alignment

### DIFF
--- a/src/wdk.js
+++ b/src/wdk.js
@@ -113,7 +113,7 @@ export default class WDK {
    */
   static isValidSeed (seed) {
     if (seed instanceof Uint8Array) {
-      return seed.length >= 16 && seed.length <= 64
+      return seed.length >= 16 && seed.length <= 64 && seed.length % 4 === 0
     }
 
     return WalletManager.isValidSeedPhrase(seed)

--- a/tests/wdk.test.js
+++ b/tests/wdk.test.js
@@ -47,6 +47,21 @@ describe('WDK', () => {
     wdk = new WDK(SEED_PHRASE)
   })
 
+  describe('isValidSeed', () => {
+    test('accepts raw seeds whose length is a multiple of 32 bits', () => {
+      expect(WDK.isValidSeed(new Uint8Array(16))).toBe(true)
+      expect(WDK.isValidSeed(new Uint8Array(20))).toBe(true)
+      expect(WDK.isValidSeed(new Uint8Array(64))).toBe(true)
+    })
+
+    test('rejects raw seeds whose length is not a multiple of 32 bits', () => {
+      expect(WDK.isValidSeed(new Uint8Array(17))).toBe(false)
+      expect(WDK.isValidSeed(new Uint8Array(63))).toBe(false)
+      expect(WDK.isValidSeed(new Uint8Array(15))).toBe(false)
+      expect(WDK.isValidSeed(new Uint8Array(65))).toBe(false)
+    })
+  })
+
   describe('getAccount', () => {
     beforeEach(() => {
       getAccountMock.mockResolvedValue(DUMMY_ACCOUNT)


### PR DESCRIPTION
Fixes #84

Raw seed validation currently accepts any Uint8Array from 16 through 64 bytes, including lengths that cannot represent a whole number of 32-bit words. Require byte length to be a multiple of 4 while preserving the existing 16–64-byte bounds.

Verification:
- npm test -- --runInBand (161 tests passed)
- npm run lint
- npm run build:types